### PR TITLE
BugFix: fix coredump of trpc::config::GetInt64() with overflowed int32

### DIFF
--- a/trpc/config/BUILD
+++ b/trpc/config/BUILD
@@ -132,6 +132,7 @@ cc_test(
     srcs = ["trpc_conf_compatible_test.cc"],
     deps = [
         ":trpc_conf",
+        "@com_github_fmtlib_fmt//:fmtlib",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],

--- a/trpc/config/trpc_conf_compatible.cc
+++ b/trpc/config/trpc_conf_compatible.cc
@@ -282,7 +282,7 @@ bool TransformConfig(const Json::Value& from, std::map<std::string, std::string>
       Json::ValueType value_type = from[*it].type();
       switch (value_type) {
         case Json::intValue: {
-          config_map->insert(std::pair<std::string, std::string>(key_name, std::to_string(from[*it].asInt())));
+          config_map->insert(std::pair<std::string, std::string>(key_name, std::to_string(from[*it].asInt64())));
           break;
         }
         case Json::uintValue: {


### PR DESCRIPTION
issue: trpc::config::GetInt64() with json may coredump when real value is greater than INT32_MAX.
cause: asInt() of json-cpp with overflowed interge will assert failure.
fix: change asInt() to asInt64().