### PR TITLE
BugFix: to avoid infinite loop in kNanosecondsPerUnit initialization …

### DIFF
--- a/trpc/coroutine/fiber.h
+++ b/trpc/coroutine/fiber.h
@@ -122,6 +122,7 @@ class Fiber {
   void Detach();
 
   /// @brief Wait for the fiber to exit.
+  /// @note  Can be run in both pthread context and fiber context.
   void Join();
 
   /// @brief Test if we can call `join()` on this object.

--- a/trpc/runtime/threadmodel/fiber/detail/waitable.cc
+++ b/trpc/runtime/threadmodel/fiber/detail/waitable.cc
@@ -401,12 +401,10 @@ void ConditionVariable::notify_all() noexcept {
 ExitBarrier::ExitBarrier() : count_(1) {}
 
 std::unique_lock<Mutex> ExitBarrier::GrabLock() {
-  TRPC_DCHECK(IsFiberContextPresent());
   return std::unique_lock(lock_);
 }
 
 void ExitBarrier::UnsafeCountDown(std::unique_lock<Mutex> lk) {
-  TRPC_DCHECK(IsFiberContextPresent());
   TRPC_CHECK(lk.owns_lock() && lk.mutex() == &lock_);
 
   // tsan reports a data race if we unlock the lock before notifying the
@@ -421,8 +419,6 @@ void ExitBarrier::UnsafeCountDown(std::unique_lock<Mutex> lk) {
 }
 
 void ExitBarrier::Wait() {
-  TRPC_DCHECK(IsFiberContextPresent());
-
   std::unique_lock lk(lock_);
   return cv_.wait(lk, [this] { return count_ == 0; });
 }

--- a/trpc/runtime/threadmodel/fiber/detail/waitable.h
+++ b/trpc/runtime/threadmodel/fiber/detail/waitable.h
@@ -248,7 +248,7 @@ class ExitBarrier : public object_pool::EnableLwSharedFromThis<ExitBarrier> {
   // Count down the barrier's internal counter and wake up waiters.
   void UnsafeCountDown(std::unique_lock<Mutex> lk);
 
-  // Won't block.
+  // Won't block, can be run in both pthread context and fiber context.
   void Wait();
 
   void Reset() { count_ = 1; }

--- a/trpc/util/chrono/tsc.h
+++ b/trpc/util/chrono/tsc.h
@@ -59,7 +59,12 @@ std::pair<std::chrono::steady_clock::time_point, std::uint64_t> ReadConsistentTi
 ///       use `std::steady_clock` instead. TSC is suitable for situations where
 ///       accuracy can be trade for speed.
 #if defined(__x86_64__) || defined(__MACHINEX86_X64)
-inline std::uint64_t ReadTsc() { return __rdtsc(); }
+inline std::uint64_t ReadTsc() {
+  unsigned int lo = 0;
+  unsigned int hi = 0;
+  asm volatile("rdtsc" : "=a" (lo), "=d" (hi));
+  return ((uint64_t)hi << 32) | lo;
+}
 #elif defined(__aarch64__)
 inline std::uint64_t ReadTsc() {
   // Sub-100MHz resolution (exactly 100MHz in our environment), not as accurate


### PR DESCRIPTION
…in x86 arch

- use rdtsc instruction instead of __rdtsc function to get tsc in x86 arch
- support fiber primitive for ExitBarrier, to allow Fiber.Join in pthread context and fiber context