### PR TITLE
BugFix: fix the issue of the client-side socket fd cannot be recycled…

### DIFF
--- a/trpc/runtime/iomodel/reactor/fiber/fiber_connection.h
+++ b/trpc/runtime/iomodel/reactor/fiber/fiber_connection.h
@@ -118,6 +118,12 @@ class alignas(hardware_destructive_interference_size) FiberConnection : public C
 
   std::atomic<std::size_t> restart_read_count_{0}, restart_write_count_{0};
 
+  // Connection closing cleanup and connection sending/receiving mutex lock, to protect connection cleanup and network
+  // data transmission/reception thread safety.
+  std::mutex mutex_;
+  // Connection unavailability status flag.
+  bool conn_unavailable_{false};
+
  private:
   void SuppressReadAndClearReadEvent();
   void SuppressAndClearWriteEvent();


### PR DESCRIPTION
… in a timely manner when using fiber connection pool, causing the number of close-wait to increase.