### PR TITLE
Feature: When accepting a server, if the created file descriptor (FD) is 0, 1, or 2, avoid asserting to prevent a core dump

### DIFF
--- a/trpc/runtime/iomodel/reactor/default/tcp_acceptor.cc
+++ b/trpc/runtime/iomodel/reactor/default/tcp_acceptor.cc
@@ -108,6 +108,10 @@ int TcpAcceptor::HandleReadEvent() {
     NetworkAddress peer_addr;
     int conn_fd = socket_.Accept(&peer_addr);
     if (conn_fd >= 0) {
+      // When Accept returns standard input(0),standard output(1),and standard error(2), just only log
+      if (conn_fd < 3) {
+        TRPC_LOG_WARN("Accept return std fd,conn_fd:" << conn_fd);
+      }
       AcceptConnectionFunction& accept_handler = GetAcceptHandleFunction();
       if (accept_handler) {
         AcceptConnectionInfo info;

--- a/trpc/runtime/iomodel/reactor/fiber/fiber_acceptor.cc
+++ b/trpc/runtime/iomodel/reactor/fiber/fiber_acceptor.cc
@@ -118,6 +118,10 @@ FiberConnection::EventAction FiberAcceptor::OnTcpReadable() {
     NetworkAddress peer_addr;
     int conn_fd = socket_.Accept(&peer_addr);
     if (conn_fd >= 0) {
+      // When Accept returns standard input(0),standard output(1),and standard error(2), just only log
+      if (conn_fd < 3) {
+        TRPC_LOG_WARN("Accept return std fd,conn_fd:" << conn_fd);
+      }
       if (accept_handler_) {
         AcceptConnectionInfo info;
 

--- a/trpc/runtime/iomodel/reactor/fiber/fiber_reactor.cc
+++ b/trpc/runtime/iomodel/reactor/fiber/fiber_reactor.cc
@@ -226,9 +226,9 @@ void TerminateAllReactor() {
 }
 
 Reactor* GetReactor(std::size_t scheduling_group, int fd) {
-  TRPC_CHECK(fd != 0 && fd != -1,
-              "You're likely passing in a fd got from calling `Get()` on an "
-              "invalid `Handle`.");
+  TRPC_CHECK(fd != -1,
+             "You're likely passing in a fd got from calling `Get()` on an "
+             "invalid `Handle`.");
   if (fd == -2) {
     fd = Random<int>();
   }


### PR DESCRIPTION
Feature: When accepting a server, if the created file descriptor (FD) is 0, 1, or 2, avoid asserting to prevent a core dump