### PR TITLE
Bugfix: libtrpc_Sadmin_Slibmutex.so: error: undefined reference to 'dl_sym'

### DIFF
--- a/trpc/admin/mutex.cc
+++ b/trpc/admin/mutex.cc
@@ -33,7 +33,7 @@
 namespace trpc::admin {
 
 extern "C" {
-extern void* _dl_sym(void* handle, const char* symbol, void* caller);
+extern void* __attribute__((weak)) _dl_sym(void* handle, const char* symbol, void* caller);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Ubuntu 22.04:
gcc version 11.4.0 (Ubuntu 11.4.0-1ubuntu1~22.04)

build.sh:
bazel-out/k8-fastbuild/bin/_solib_k8/libtrpc_Sadmin_Slibmutex.so: error: undefined reference to '_dl_sym'
collect2: error: ld returned 1 exit status