### PR TITLE
BugFix: connection can't send data while http async stream write empty data.

### DIFF
--- a/trpc/stream/http/async/stream.cc
+++ b/trpc/stream/http/async/stream.cc
@@ -48,6 +48,11 @@ Future<> HttpAsyncStream::PushSendMessage(HttpStreamFramePtr&& msg) {
   if (IsStateTerminate()) {
     Stop();
   }
+  // If got empty buffer, there is no need to write to connection.
+  // Maybe caused by invoking `WriteDone` at content-length mode.
+  if (out.ByteSize() == 0) {
+    return MakeReadyFuture<>();
+  }
   return AsyncWrite(std::move(out));
 }
 


### PR DESCRIPTION
- At content-length mode, invoking WriteDone of http async stream will write empty data to connection so that TcpClientConnection canculate wrong io_msgs_ size.