### PR TITLE
Bugfix: Fix some HTTP-related issues

### DIFF
--- a/trpc/client/http/http_service_proxy.cc
+++ b/trpc/client/http/http_service_proxy.cc
@@ -68,14 +68,15 @@ Future<ProtocolPtr> HttpServiceProxy::AsyncInnerUnaryInvoke(const ClientContextP
       ProtocolPtr p = rsp.GetValue0();
       // When the call is successful, set the response data (for use by the `CLIENT_POST_RPC_INVOKE` filter).
       context->SetResponseData(&p);
-      filter_controller_.RunMessageClientFilters(FilterPoint::CLIENT_POST_RPC_INVOKE, context);
       if (!CheckHttpResponse(context, p)) {
         std::string error = fmt::format("service name:{},check http reply failed,{}", GetServiceName(),
                                         context->GetStatus().ToString());
         TRPC_LOG_ERROR(error);
+        filter_controller_.RunMessageClientFilters(FilterPoint::CLIENT_POST_RPC_INVOKE, context);
         return MakeExceptionFuture<ProtocolPtr>(
             CommonException(context->GetStatus().ErrorMessage().c_str(), context->GetStatus().GetFuncRetCode()));
       }
+      filter_controller_.RunMessageClientFilters(FilterPoint::CLIENT_POST_RPC_INVOKE, context);
       return MakeReadyFuture<ProtocolPtr>(std::move(p));
     }
 

--- a/trpc/codec/http/http_protocol.cc
+++ b/trpc/codec/http/http_protocol.cc
@@ -57,6 +57,10 @@ bool HttpRequestProtocol::WaitForFullRequest() {
   return false;
 }
 
+uint32_t HttpRequestProtocol::GetMessageSize() const { return request->ContentLength(); }
+
+uint32_t HttpResponseProtocol::GetMessageSize() const { return response.ContentLength(); }
+
 namespace internal {
 const std::string& GetHeaderString(const http::HeaderPairs& header, const std::string& name) {
   return header.Get(name);

--- a/trpc/codec/http/http_protocol.h
+++ b/trpc/codec/http/http_protocol.h
@@ -72,6 +72,9 @@ class HttpRequestProtocol : public Protocol {
   void SetFromHttpServiceProxy(bool from_http_service_proxy) { from_http_service_proxy_ = from_http_service_proxy; }
   bool IsFromHttpServiceProxy() { return from_http_service_proxy_; }
 
+  /// @brief Get size of message
+  uint32_t GetMessageSize() const override;
+
  public:
   uint32_t request_id{0};
   http::RequestPtr request{nullptr};
@@ -100,6 +103,9 @@ class HttpResponseProtocol : public Protocol {
   NoncontiguousBuffer GetNonContiguousProtocolBody() override {
     return std::move(*response.GetMutableNonContiguousBufferContent());
   }
+
+  /// @brief Get size of message
+  uint32_t GetMessageSize() const override;
 
  public:
   http::Response response;

--- a/trpc/codec/http/http_protocol_test.cc
+++ b/trpc/codec/http/http_protocol_test.cc
@@ -35,8 +35,9 @@ TEST_F(HttpProtoFixture, HttpRequestProtocolTest) {
   HttpRequestProtocol req = HttpRequestProtocol(std::make_shared<http::Request>());
   req.request->SetContent(test);
   NoncontiguousBuffer buff;
-  EXPECT_FALSE(req.ZeroCopyDecode(buff));
-  EXPECT_FALSE(req.ZeroCopyEncode(buff));
+  ASSERT_FALSE(req.ZeroCopyDecode(buff));
+  ASSERT_FALSE(req.ZeroCopyEncode(buff));
+  ASSERT_NE(0, req.GetMessageSize());
 }
 
 TEST_F(HttpProtoFixture, HttpResponseProtocolTest) {
@@ -47,8 +48,9 @@ TEST_F(HttpProtoFixture, HttpResponseProtocolTest) {
   reply.SetStatus(trpc::http::HttpResponse::StatusCode::kOk);
   reply.SetContent("{\"age\":\"18\",\"height\":180}");
   NoncontiguousBuffer buff;
-  EXPECT_FALSE(rsp.ZeroCopyDecode(buff));
-  EXPECT_FALSE(rsp.ZeroCopyEncode(buff));
+  ASSERT_FALSE(rsp.ZeroCopyDecode(buff));
+  ASSERT_FALSE(rsp.ZeroCopyEncode(buff));
+  ASSERT_NE(0, rsp.GetMessageSize());
 }
 
 TEST(HttpRequestProtocolTest, GetOkNonContiguousProtocolBody) {
@@ -59,13 +61,13 @@ TEST(HttpRequestProtocolTest, GetOkNonContiguousProtocolBody) {
   request_protocol.SetNonContiguousProtocolBody(builder.DestructiveGet());
 
   auto body_buffer = request_protocol.GetNonContiguousProtocolBody();
-  EXPECT_EQ(greetings.size(), body_buffer.ByteSize());
+  ASSERT_EQ(greetings.size(), body_buffer.ByteSize());
 }
 
 TEST(HttpRequestProtocolTest, GetEmptyNonContiguousProtocolBody) {
   HttpRequestProtocol request_protocol{std::make_shared<http::HttpRequest>()};
   auto body_buffer = request_protocol.GetNonContiguousProtocolBody();
-  EXPECT_EQ(0, body_buffer.size());
+  ASSERT_EQ(0, body_buffer.size());
 }
 
 TEST(HttpResponseProtocolTest, GetOkNonContiguousProtocolBody) {
@@ -74,8 +76,8 @@ TEST(HttpResponseProtocolTest, GetOkNonContiguousProtocolBody) {
 
   response_protocol.SetNonContiguousProtocolBody(CreateBufferSlow(greetings));
 
-  EXPECT_EQ(greetings.size(), response_protocol.GetNonContiguousProtocolBody().ByteSize());
-  EXPECT_TRUE(response_protocol.response.GetContent().empty());
+  ASSERT_EQ(greetings.size(), response_protocol.GetNonContiguousProtocolBody().ByteSize());
+  ASSERT_TRUE(response_protocol.response.GetContent().empty());
 }
 
 TEST(EncodeTypeToMimeTest, EncodeTypeToMime) {
@@ -92,7 +94,7 @@ TEST(EncodeTypeToMimeTest, EncodeTypeToMime) {
   };
 
   for (const auto& t : testings) {
-    EXPECT_EQ(t.expect, EncodeTypeToMime(t.encode_type));
+    ASSERT_EQ(t.expect, EncodeTypeToMime(t.encode_type));
   }
 }
 
@@ -112,7 +114,7 @@ TEST(MimeToEncodeTypeTest, MimeToEncodeType) {
   };
 
   for (const auto& t : testings) {
-    EXPECT_EQ(t.expect, MimeToEncodeType(t.mime));
+    ASSERT_EQ(t.expect, MimeToEncodeType(t.mime));
   }
 }
 

--- a/trpc/util/http/field_map.h
+++ b/trpc/util/http/field_map.h
@@ -79,7 +79,7 @@ class FieldMap {
   /// @brief  Does same thing as Set method, but only works when key does not exist in the map.
   template <typename K, typename V>
   void SetIfNotPresent(K&& key, V&& value) {
-    if (auto it = pairs_.lower_bound(key); it == pairs_.end() || it->first != key) {
+    if (auto it = pairs_.lower_bound(key); it == pairs_.end() || !CaseInsensitiveEqualTo()(it->first, key)) {
       pairs_.emplace_hint(it, std::forward<K>(key), std::forward<V>(value));
     }
   }

--- a/trpc/util/http/field_map_test.cc
+++ b/trpc/util/http/field_map_test.cc
@@ -207,4 +207,22 @@ TEST_F(FieldMapTest, FlatPairsCount) {
   ASSERT_EQ(17, header_.FlatPairsCount());
 }
 
+TEST_F(FieldMapTest, SetIfNotPresentOk) {
+  EXPECT_EQ(0, header_.Values("User-Defined-Key99").size());
+  header_.SetIfNotPresent("User-Defined-Key99", "user-defined-value99");
+  EXPECT_EQ(1, header_.Values("User-Defined-Key99").size());
+  EXPECT_EQ("user-defined-value99", header_.Get("User-Defined-Key99"));
+
+  EXPECT_EQ(1, header_.Values("User-Defined-Key01").size());
+  header_.SetIfNotPresent("User-Defined-Key01", "user-defined-value01-new");
+  EXPECT_EQ(1, header_.Values("User-Defined-Key01").size());
+  EXPECT_EQ("user-defined-value01", header_.Get("User-Defined-Key01"));
+
+  // case insensitivity test
+  EXPECT_EQ(1, header_.Values("user-defined-key01").size());
+  header_.SetIfNotPresent("user-defined-key01", "user-defined-value01-new");
+  EXPECT_EQ(1, header_.Values("user-defined-key01").size());
+  EXPECT_EQ("user-defined-value01", header_.Get("user-defined-key01"));
+}
+
 }  // namespace trpc::http::testing


### PR DESCRIPTION
- Fix the issue where metrics reports as correct when the HTTP client's asynchronous call returns an erroneous HTTP response code
- Fix the issue of rpcz not correctly obtaining the size of the HTTP client response packet
- Fix the case sensitivity issue in key comparison for HttpHeader.SetIfNotPresent interfac