### PR TITLE
chore: add .bazelignore

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,1 @@
+cmake_third_party


### PR DESCRIPTION
When compiling with bazel, ignore all files under cmake_third_party so that `bazel build...` works properly