### PR TITLE
【腾讯犀牛鸟计划】实现IP直连负载均衡插件 - 加权轮询算法

### DIFF
--- a/lwk/run_test.sh
+++ b/lwk/run_test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+
+echo "Running Bazel test..."
+bazel test //trpc/naming/common/util/loadbalance/weightpolling:test_weight_polling_load_balance
+
+
+if [ $? -eq 0 ]; then
+    echo "Bazel test completed successfully."
+else
+    echo "Bazel test failed."
+    exit 1
+fi
+
+
+echo "Running test executable..."
+../bazel-bin/trpc/naming/common/util/loadbalance/weightpolling/test_weight_polling_load_balance
+
+
+if [ $? -eq 0 ]; then
+    echo "Test executable completed successfully."
+else
+    echo "Test executable failed."
+    exit 1
+fi

--- a/trpc/naming/common/util/loadbalance/weightpolling/BUILD
+++ b/trpc/naming/common/util/loadbalance/weightpolling/BUILD
@@ -1,0 +1,27 @@
+# Description: trpc-cpp.
+
+licenses(["notice"])
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "weight_polling_load_balance",
+    srcs = ["weight_polling_load_balance.cc"],
+    hdrs = ["weight_polling_load_balance.h"],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//trpc/naming:load_balance_factory",
+        "//trpc/util/log:logging",
+    ],
+)
+cc_test(
+    name = "test_weight_polling_load_balance",
+    srcs = ["test_weight_polling_load_balance.cc"],
+    deps = [
+        "//trpc/naming:load_balance_factory",
+        "//trpc/util/log:logging",
+        ":weight_polling_load_balance"
+    ],
+)

--- a/trpc/naming/common/util/loadbalance/weightpolling/test_weight_polling_load_balance.cc
+++ b/trpc/naming/common/util/loadbalance/weightpolling/test_weight_polling_load_balance.cc
@@ -1,0 +1,76 @@
+//#include "test_weight_polling_load_balance.h"
+#include "trpc/naming/load_balance.h"
+#include "weight_polling_load_balance.h"
+#include <iostream>
+
+void TestWeightPollingLoadBalance() {
+  using namespace trpc;
+
+  WeightPollingLoadBalance lb;
+
+  // 定义一些测试节点
+  std::vector<TrpcEndpointInfo> endpoints = {
+    {
+        "A",  // host   为了方便看
+        4,           // port   为了方便看，写成权重
+        1,              // status (表示健康状态的整数)
+        false,          // is_ipv6 (表示是否为IPv6地址)
+        4,              // weight (权重)
+        1001,           // id (节点的唯一ID)
+        {{"region", "us-east"}, {"version", "v1"}}  // meta (扩展信息字段)
+    },
+    {
+        "B",
+        2,
+        1,
+        false,
+        2,
+        1002,
+        {{"region", "us-west"}, {"version", "v1"}}
+    },
+    {
+        "C",
+        1,
+        1,
+        false,
+        1,
+        1003,
+        {{"region", "eu-central"}, {"version", "v2"}}
+    }
+};
+
+  LoadBalanceInfo info;
+  SelectorInfo selector_info;
+  selector_info.name = "test_service";
+  info.info = &selector_info;
+  info.endpoints = &endpoints;
+
+  lb.Update(&info);
+
+  // 模拟请求并测试负载均衡结果
+  const int request_count = 14;  // 总请求数
+  std::unordered_map<std::string, int> request_distribution;
+
+  for (int i = 0; i < request_count; ++i) {
+    LoadBalanceResult result;
+    result.info = &selector_info;
+    lb.Next(result);
+     // 将 std::any 转换为 TrpcEndpointInfo
+    TrpcEndpointInfo endpoint = std::any_cast<TrpcEndpointInfo>(result.result);
+    std::string endpoint_key = endpoint.host + ":" + std::to_string(endpoint.port);
+    
+    std::cout << "Request #" << (i + 1) << ": Endpoint: " << endpoint_key << ": ID: " << endpoint.id<< std::endl;
+
+     ++request_distribution[endpoint_key];
+  }
+
+    std::cout << "Request distribution after " << request_count << " requests:" << std::endl;
+    for (const auto& entry : request_distribution) {
+        std::cout << "Endpoint: " << entry.first << ", Requests: " << entry.second << std::endl;
+    }
+}
+
+int main() {
+  TestWeightPollingLoadBalance();
+  return 0;
+}

--- a/trpc/naming/common/util/loadbalance/weightpolling/weight_polling_load_balance.cc
+++ b/trpc/naming/common/util/loadbalance/weightpolling/weight_polling_load_balance.cc
@@ -1,0 +1,128 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 THL A29 Limited, a Tencent company.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+#include "weight_polling_load_balance.h"
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <sys/socket.h>
+
+#include <algorithm>
+#include <any>
+#include <iostream>
+#include <regex>
+#include <vector>
+
+#include "trpc/naming/load_balance_factory.h"
+#include "trpc/util/log/logging.h"
+
+namespace trpc {
+
+bool WeightPollingLoadBalance::IsLoadBalanceInfoDiff(const LoadBalanceInfo* info) {
+  if (nullptr == info || nullptr == info->info || nullptr == info->endpoints) {
+    return false;
+  }
+
+  const SelectorInfo* select_info = info->info;
+  std::shared_lock<std::shared_mutex> lock(mutex_);
+  if (callee_router_infos_.end() == callee_router_infos_.find(select_info->name)) {
+    return true;
+  }
+
+  std::vector<TrpcEndpointInfo>& orig_endpoints = callee_router_infos_[select_info->name].endpoints;
+
+  const std::vector<TrpcEndpointInfo>* new_endpoints = info->endpoints;
+  if (orig_endpoints.size() != new_endpoints->size()) {
+    return true;
+  }
+
+  int i = 0;
+  for (auto& var : *new_endpoints) {
+    auto orig_endpoint = orig_endpoints[i++];
+    if (orig_endpoint.host != var.host || orig_endpoint.port != var.port) {
+      return true;
+    }
+
+    if (orig_endpoint.weight != var.weight) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// Update the routing nodes used for load balancing
+int WeightPollingLoadBalance::Update(const LoadBalanceInfo* info) {
+  if (nullptr == info || nullptr == info->info || nullptr == info->endpoints) {
+    TRPC_LOG_ERROR("Endpoint info of name is empty");
+    return -1;
+  }
+
+  const SelectorInfo* select_info = info->info;
+  if (IsLoadBalanceInfoDiff(info)) {
+    InnerEndpointInfos endpoint_info;
+    endpoint_info.index = 0;
+    endpoint_info.total = 0;
+
+    for (const auto& endpoint : *info->endpoints) {
+      endpoint_info.endpoints.push_back(endpoint);
+      endpoint_info.current_weight.push_back(0);
+      endpoint_info.total += endpoint.weight;
+    }
+
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    callee_router_infos_[select_info->name] = endpoint_info;
+  }
+
+  return 0;
+}
+
+// Used to return a regulated point
+int WeightPollingLoadBalance::Next(LoadBalanceResult& result) {
+  if (nullptr == result.info) {
+    return -1;
+  }
+
+  std::shared_lock<std::shared_mutex> lock(mutex_);
+  auto iter = callee_router_infos_.find((result.info)->name);
+  if (iter == callee_router_infos_.end()) {
+    TRPC_LOG_ERROR("Router info of name " << (result.info)->name << " no found");
+    return -1;
+  }
+
+  std::vector<TrpcEndpointInfo>& endpoints = iter->second.endpoints;
+  size_t endpoints_num = endpoints.size();
+  if (endpoints_num < 1) {
+    TRPC_LOG_ERROR("Router info of name is empty");
+    return -1;
+  }
+
+  InnerEndpointInfos& endpoint_info = iter->second;
+  int max_weight = std::numeric_limits<int>::min();
+  int index;
+  for (size_t i = 0; i < endpoints_num; ++i) {
+    endpoint_info.current_weight[i] += endpoints[i].weight;
+    if (endpoint_info.current_weight[i] > max_weight) {
+      max_weight = endpoint_info.current_weight[i];
+      index = i;
+    }
+  }
+
+  result.result = endpoints[index];
+
+  endpoint_info.current_weight[index] -= endpoint_info.total;
+
+  return 0;
+}
+
+}  // namespace trpc

--- a/trpc/naming/common/util/loadbalance/weightpolling/weight_polling_load_balance.h
+++ b/trpc/naming/common/util/loadbalance/weightpolling/weight_polling_load_balance.h
@@ -1,0 +1,63 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 THL A29 Limited, a Tencent company.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <set>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "trpc/naming/load_balance.h"
+
+namespace trpc {
+
+constexpr char kWeightPollingLoadBalance[] = "trpc_weight_polling_load_balance";
+
+/// @brief Weighted round-robin load balancing plugin
+class WeightPollingLoadBalance : public LoadBalance {
+ public:
+  WeightPollingLoadBalance() = default;
+
+  ~WeightPollingLoadBalance() = default;
+
+  /// @brief Get the name of the load balancing plugin
+  std::string Name() const override { return kWeightPollingLoadBalance; }
+
+  /// @brief Update the routing node information used by the load balancing
+  int Update(const LoadBalanceInfo* info) override;
+
+  /// @brief Return a callee node
+  int Next(LoadBalanceResult& result) override;
+
+ private:
+  /// @brief Check if the load balancing information is different
+  bool IsLoadBalanceInfoDiff(const LoadBalanceInfo* info);
+
+  struct InnerEndpointInfos {
+    std::vector<TrpcEndpointInfo> endpoints;
+    std::uint32_t index;
+    std::vector<int> current_weight;
+    std::uint32_t total;
+  };
+
+  std::unordered_map<std::string, WeightPollingLoadBalance::InnerEndpointInfos> callee_router_infos_;
+  mutable std::shared_mutex mutex_;
+};
+
+using WeightPollingLoadBalancePtr = RefPtr<WeightPollingLoadBalance>;
+
+}  // namespace trpc


### PR DESCRIPTION
对应issues：https://github.com/trpc-group/trpc-cpp/issues/140

实现加权轮询负载均衡weight_polling_load_balance

test_weight_polling_load_balance.cc是其测试代码，运行run_test.sh即可开始测试