### PR TITLE
fix compilation problems on gcc-14.2

### DIFF
--- a/cmake/gtest_gmock.cmake
+++ b/cmake/gtest_gmock.cmake
@@ -13,7 +13,7 @@
 
 include(FetchContent)
 
-set(GTEST_VET  1.10.0)
+set(GTEST_VET  1.11.0)
 set(GTEST_URL  https://github.com/google/googletest/archive/release-${GTEST_VET}.tar.gz)
 
 FetchContent_Declare(

--- a/cmake/rapidjson.cmake
+++ b/cmake/rapidjson.cmake
@@ -28,6 +28,10 @@ FetchContent_GetProperties(com_github_tencent_rapidjson)
 if(NOT com_github_tencent_rapidjson_POPULATED)
     FetchContent_Populate(com_github_tencent_rapidjson)
 
+    execute_process(COMMAND git apply ${TRPC_ROOT_PATH}/third_party/com_github_tencent_rapidjson/0001-remove-non-compiling-assignment-operator.patch
+                                      --directory cmake_third_party/rapidjson
+                    WORKING_DIRECTORY ${TRPC_ROOT_PATH})
+
     add_definitions(-DRAPIDJSON_HAS_STDSTRING)
     include_directories("${TRPC_ROOT_PATH}/cmake_third_party/rapidjson/include/")
 

--- a/third_party/com_github_tencent_rapidjson/0001-remove-non-compiling-assignment-operator.patch
+++ b/third_party/com_github_tencent_rapidjson/0001-remove-non-compiling-assignment-operator.patch
@@ -1,0 +1,25 @@
+From 4bd1e5f857adfc3363126e2001de935183808f1a Mon Sep 17 00:00:00 2001
+From: zhangyi1357 <zhangyi_1357@sjtu.edu.cn>
+Date: Wed, 7 Aug 2024 14:31:29 +0800
+Subject: [PATCH] remove non-compiling assignment operator
+
+---
+ include/rapidjson/document.h | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/include/rapidjson/document.h b/include/rapidjson/document.h
+index e3e20dfb..b0f1f70b 100644
+--- a/include/rapidjson/document.h
++++ b/include/rapidjson/document.h
+@@ -316,8 +316,6 @@ struct GenericStringRef {
+ 
+     GenericStringRef(const GenericStringRef& rhs) : s(rhs.s), length(rhs.length) {}
+ 
+-    GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
+-
+     //! implicit conversion to plain CharType pointer
+     operator const Ch *() const { return s; }
+ 
+-- 
+2.46.0
+

--- a/trpc/config/trpc_conf_compatible.h
+++ b/trpc/config/trpc_conf_compatible.h
@@ -41,8 +41,8 @@ std::optional<T> LoadConfig(const std::string& plugin_name, const std::string& c
                             const std::any& params = nullptr) {
   std::optional<T> ret;
   // Determine the type of support
-  if constexpr (std::negation_v<T, Json::Value> && std::negation_v<T, YAML::Node> &&
-                std::negation_v<T, std::map<std::string, std::string> >) {
+  if constexpr (std::negation_v<std::is_same<T, Json::Value>> && std::negation_v<std::is_same<T, YAML::Node>> &&
+                std::negation_v<std::is_same<T, std::map<std::string, std::string>>>) {
     TRPC_LOG_ERROR("Unknown type!");
     return ret;
   }


### PR DESCRIPTION
Makes trpc successfully built under gcc-14.2 on Arch Linux.

Fixes #166.