### PR TITLE
Bugfix: Set format from parent config

### DIFF
--- a/trpc/util/log/default/default_log.h
+++ b/trpc/util/log/default/default_log.h
@@ -113,6 +113,9 @@ class DefaultLog : public Log {
     if (!YAML::GetDefaultLoggerSinkConfig<SinkConfig>(conf.name, "sinks", sink_name, sink_config)) {
       return true;
     }
+    if (sink_config.format.empty()) {
+      sink_config.format = conf.format;
+    }
     auto sink = MakeRefCounted<Sink>();
     sink->Init(sink_config);
     // Add the new sink to the logger's sinks


### PR DESCRIPTION
set `format` from parent config when there is not format of the sink config 