### PR TITLE
Bugfix: fixed the following bugs

### DIFF
--- a/trpc/client/http/http_service_proxy.h
+++ b/trpc/client/http/http_service_proxy.h
@@ -394,6 +394,7 @@ Status HttpServiceProxy::HttpUnaryInvoke(const ClientContextPtr& context, const 
 
   if (context->GetStatus().OK()) {
     auto* ret_rsp = static_cast<HttpResponseProtocol*>(rsp_protocol.get());
+    ret_rsp->response.SetNonContiguousBufferContent(ret_rsp->GetNonContiguousProtocolBody());
     *rsp = std::move(ret_rsp->response);
   }
   return context->GetStatus();
@@ -425,6 +426,7 @@ Future<ResponseMessage> HttpServiceProxy::AsyncHttpUnaryInvoke(const ClientConte
 
       ProtocolPtr& rsp_protocol = context->GetResponse();
       auto* rsp = static_cast<HttpResponseProtocol*>(rsp_protocol.get());
+      rsp->response.SetNonContiguousBufferContent(rsp->GetNonContiguousProtocolBody());
       return MakeReadyFuture<ResponseMessage>(std::move(rsp->response));
     }
     return MakeExceptionFuture<ResponseMessage>(rsp_fut.GetException());

--- a/trpc/client/http/http_service_proxy_test.cc
+++ b/trpc/client/http/http_service_proxy_test.cc
@@ -3335,6 +3335,7 @@ TEST_F(HttpServiceProxyTest, HttpUnaryInvoke) {
   EXPECT_EQ(reply.GetVersion(), rep.GetVersion());
   EXPECT_EQ(reply.GetStatus(), rep.GetStatus());
   EXPECT_EQ(str, rep.GetContent());
+  EXPECT_EQ(str, FlattenSlow(rep.GetNonContiguousBufferContent()));
 
   HttpRequestProtocol* http_req_protocol = static_cast<HttpRequestProtocol*>(ctx->GetRequest().get());
   EXPECT_EQ(http_req_protocol->request->GetMethodType(), http::OperationType::POST);
@@ -3354,6 +3355,7 @@ TEST_F(HttpServiceProxyTest, HttpUnaryInvoke) {
             EXPECT_EQ(reply.GetVersion(), rep.GetVersion());
             EXPECT_EQ(reply.GetStatus(), rep.GetStatus());
             EXPECT_EQ(str, rep.GetContent());
+            EXPECT_EQ(str, FlattenSlow(rep.GetNonContiguousBufferContent()));
             return MakeReadyFuture<>();
           });
   future::BlockingGet(std::move(async_unary_invoke_fut));

--- a/trpc/util/object_pool/object_pool.h
+++ b/trpc/util/object_pool/object_pool.h
@@ -75,7 +75,8 @@ inline void Delete(T* ptr) {
 }  // namespace detail
 
 /// @brief Allocate and construct an object (thread-safe).
-/// @example
+/// @code
+/// example
 ///   struct A {
 ///     int a;
 ///   };
@@ -90,6 +91,7 @@ inline void Delete(T* ptr) {
 ///   #endif
 ///   A* a_p = trpc::object_pool::New<A>();
 ///   trpc::object_pool::Delete(a_p);
+/// @endcode
 template <class T, class... Args>
 T* New(Args&&... args) {
   // Remove CV attributes. We do not differentiate between T, const T, volatile T, and const volatile T,


### PR DESCRIPTION
- fixed the issue that the GetNonContiguousBufferContent interface of the HttpResponse output parameter using the HttpUnaryInvoke method could not obtain data

- fixed the issue that the https client would cause coredump if the ca_cert_path parameter is not configured