### PR TITLE
Bugfix: fixed the following bugs

### DIFF
--- a/trpc/naming/domain/selector_domain_test.cc
+++ b/trpc/naming/domain/selector_domain_test.cc
@@ -78,7 +78,7 @@ TEST(SelectorDomainTest, select_test) {
   result.context = MakeRefCounted<ClientContext>(trpc_codec);
   result.context->SetCallerName("test_service");
 
-  result.context->SetAddr("192.168.0.1", 1001);
+  result.context->SetAddr("127.0.0.1", 1001);
   int ret = ptr->ReportInvokeResult(&result);
   EXPECT_EQ(0, ret);
 

--- a/trpc/server/trpc_server.h
+++ b/trpc/server/trpc_server.h
@@ -149,6 +149,7 @@ class TrpcServer {
   void BuildTrpcRegistryInfo(const ServiceAdapterOption& option, TrpcRegistryInfo& registry_info);
   bool CheckSharedTransportConfig(const ServiceConfig& first_service_conf, const ServiceConfig& service_conf);
   std::string GetSharedKey(const ServiceConfig& config);
+  void RegisterServiceHeartBeatInfo(const std::string& service_name, const ServiceAdapterPtr& service_adapter);
 
  private:
   // stop running

--- a/trpc/transport/client/fiber/conn_pool/fiber_udp_io_pool_connector.h
+++ b/trpc/transport/client/fiber/conn_pool/fiber_udp_io_pool_connector.h
@@ -52,6 +52,8 @@ class FiberUdpIoPoolConnector final : public RefCounted<FiberUdpIoPoolConnector>
 
   void Destroy();
 
+  void DoClose();
+
   void SaveCallContext(CTransportReqMsg* req_msg, CTransportRspMsg* rsp_msg, OnCompletionFunction&& cb);
 
   void SendReqMsg(CTransportReqMsg* req_msg);

--- a/trpc/transport/client/fiber/conn_pool/fiber_udp_io_pool_connector_group.cc
+++ b/trpc/transport/client/fiber/conn_pool/fiber_udp_io_pool_connector_group.cc
@@ -180,17 +180,16 @@ void FiberUdpIoPoolConnectorGroup::Reclaim(uint64_t id) {
 
 void FiberUdpIoPoolConnectorGroup::Reclaim(int ret, RefPtr<FiberUdpIoPoolConnector>& connector) {
   if (connector->GetConnId() == 0) {
-    connector->Stop();
-    connector->Destroy();
+    connector->DoClose();
     return;
   }
 
   if (ret == 0) {
     Reclaim(connector->GetConnId());
   } else {
-    connector->Stop();
-    connector->Destroy();
+    connector->DoClose();
     udp_pool_[connector->GetConnId()] = nullptr;
+    Reclaim(connector->GetConnId());
   }
 }
 


### PR DESCRIPTION
- Resolved RPC call would hang in fiber UDP IO pool when exceeding max_conn_num threshold.​
- Adjust the heartbeat reporting logic to after port listening, to avoid service failures from premature traffic during RegisterService-to-port-binding latency.