### PR TITLE
refactor: reduce dependencies

### DIFF
--- a/trpc/admin/BUILD
+++ b/trpc/admin/BUILD
@@ -78,7 +78,6 @@ cc_library(
     srcs = ["base_funcs.cc"],
     hdrs = ["base_funcs.h"],
     deps = [
-        "//trpc/common/config:trpc_config",
         "//trpc/util/log:logging",
     ],
 )

--- a/trpc/codec/grpc/http2/BUILD
+++ b/trpc/codec/grpc/http2/BUILD
@@ -67,7 +67,7 @@ cc_library(
     hdrs = ["response.h"],
     deps = [
         ":http2",
-        "//trpc/util/http:response",
+        "//trpc/util/http:response_hdrs",
     ],
 )
 

--- a/trpc/common/config/BUILD
+++ b/trpc/common/config/BUILD
@@ -87,7 +87,8 @@ cc_library(
     ],
     deps = [
         ":config_helper",
-        ":default_log_conf",
+        ":default_log_conf_parser",
+        ":default_log_conf_h",
         "@com_github_jbeder_yaml_cpp//:yaml-cpp",
     ],
 )

--- a/trpc/compressor/BUILD
+++ b/trpc/compressor/BUILD
@@ -45,7 +45,6 @@ cc_library(
         "//trpc/compressor/zlib:zlib_compressor",
         "//trpc/log:trpc_log",
         "//trpc/util:likely",
-        "//trpc/util/buffer",
         "//trpc/util/log:logging",
     ],
 )

--- a/trpc/compressor/common/BUILD
+++ b/trpc/compressor/common/BUILD
@@ -17,7 +17,6 @@ cc_library(
     srcs = ["zlib_util.cc"],
     hdrs = ["zlib_util.h"],
     deps = [
-        "//trpc/compressor",
         "//trpc/compressor:compressor_type",
         "//trpc/util/buffer:zero_copy_stream",
         "//trpc/util/log:logging",

--- a/trpc/compressor/lz4/BUILD
+++ b/trpc/compressor/lz4/BUILD
@@ -20,10 +20,8 @@ cc_library(
     srcs = ["lz4_util.cc"],
     hdrs = ["lz4_util.h"],
     deps = [
-        "//trpc/compressor",
         "//trpc/compressor:compressor_type",
         "//trpc/compressor/common:util",
-        "//trpc/util/buffer",
         "//trpc/util/buffer:zero_copy_stream",
         "//trpc/util/log:logging",
         "@com_github_lz4_lz4//:lz4",
@@ -36,6 +34,7 @@ cc_test(
     deps = [
         ":lz4_compressor",
         "//trpc/compressor/testing:compressor_testing",
+        "//trpc/util/buffer",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],

--- a/trpc/filter/BUILD
+++ b/trpc/filter/BUILD
@@ -103,7 +103,6 @@ cc_test(
         ":client_filter_manager",
         "//trpc/client:client_context",
         "//trpc/codec/trpc:trpc_client_codec",
-        "//trpc/filter:filter_controller",
         "//trpc/filter/testing:client_filter_testing",
     ],
 )
@@ -124,7 +123,7 @@ cc_test(
     deps = [
         ":client_filter_manager",
         "//trpc/client:client_context",
-        "//trpc/filter:filter_controller",
+        ":filter_controller_h",
         "//trpc/filter/testing:client_filter_testing",
     ],
 )
@@ -143,7 +142,6 @@ cc_test(
     deps = [
         ":server_filter_controller",
         ":server_filter_manager",
-        "//trpc/filter:filter_controller",
         "//trpc/filter/testing:server_filter_testing",
         "//trpc/server:server_context",
     ],

--- a/trpc/naming/common/util/loadbalance/weighted_round_robin/BUILD
+++ b/trpc/naming/common/util/loadbalance/weighted_round_robin/BUILD
@@ -13,7 +13,7 @@ cc_library(
     ],
     deps = [
         "//trpc/common/config:trpc_config",
-        "//trpc/naming:load_balance_factory",
+        "//trpc/naming:load_balance",
         "//trpc/util/log:logging",
     ],
 )

--- a/trpc/overload_control/BUILD
+++ b/trpc/overload_control/BUILD
@@ -46,6 +46,5 @@ cc_library(
     hdrs = ["trpc_overload_control.h"],
     deps = [
         ":server_overload_controller_factory",
-        "//trpc/filter:filter_manager",
     ],
 )

--- a/trpc/runtime/common/BUILD
+++ b/trpc/runtime/common/BUILD
@@ -12,7 +12,6 @@ cc_library(
         "//trpc/util:likely",
         "//trpc/util:ref_ptr",
         "//trpc/util/log:logging",
-        "//trpc/util/thread:latch",
         "//trpc/util/thread:thread_helper",
     ],
 )
@@ -22,6 +21,7 @@ cc_test(
     srcs = ["periphery_task_scheduler_test.cc"],
     deps = [
         ":periphery_task_scheduler",
+        "//trpc/util/thread:latch",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/trpc/serialization/noop/BUILD
+++ b/trpc/serialization/noop/BUILD
@@ -8,7 +8,6 @@ cc_library(
     hdrs = ["noop_serialization.h"],
     deps = [
         "//trpc/serialization",
-        "//trpc/util/buffer:zero_copy_stream",
         "//trpc/util/log:logging",
     ],
 )

--- a/trpc/stream/BUILD
+++ b/trpc/stream/BUILD
@@ -43,7 +43,6 @@ cc_library(
     deps = [
         ":stream_handler",
         ":stream_message",
-        ":stream_var",
         "//trpc/codec:protocol",
         "//trpc/coroutine:fiber",
     ],

--- a/trpc/stream/grpc/BUILD
+++ b/trpc/stream/grpc/BUILD
@@ -10,7 +10,6 @@ cc_library(
         ":util",
         "//trpc/codec:client_codec_factory",
         "//trpc/codec/grpc:grpc_protocol",
-        "//trpc/runtime/iomodel/reactor/fiber:fiber_connection",
         "//trpc/stream:client_stream_handler_factory",
         "//trpc/transport/client/fiber/common:fiber_client_connection_handler",
         "//trpc/transport/client/future/conn_complex:future_conn_complex_connection_handler",
@@ -91,7 +90,6 @@ cc_library(
     hdrs = ["grpc_server_stream.h"],
     deps = [
         ":grpc_stream",
-        "//trpc/codec/grpc/http2:server_session",
         "//trpc/filter:server_filter_controller",
         "//trpc/server:method",
         "//trpc/server:server_context",
@@ -122,7 +120,6 @@ cc_library(
     srcs = ["grpc_server_stream_connection_handler.cc"],
     hdrs = ["grpc_server_stream_connection_handler.h"],
     deps = [
-        ":grpc_io_handler",
         ":util",
         "//trpc/codec:server_codec_factory",
         "//trpc/codec/grpc:grpc_protocol",
@@ -139,6 +136,7 @@ cc_test(
     name = "grpc_server_stream_connection_handler_test",
     srcs = ["grpc_server_stream_connection_handler_test.cc"],
     deps = [
+        ":grpc_io_handler",
         ":grpc_server_stream_connection_handler",
         "//trpc/codec:codec_manager",
         "//trpc/coroutine/testing:fiber_runtime_test",
@@ -184,7 +182,7 @@ cc_library(
         "//trpc/codec/grpc:grpc_protocol",
         "//trpc/codec/grpc:grpc_stream_frame",
         "//trpc/codec/grpc/http2:session",
-        "//trpc/filter:filter_controller",
+        "//trpc/filter:filter_controller_h",
         "//trpc/stream:common_stream",
         "//trpc/stream:stream_var",
     ],

--- a/trpc/stream/http/BUILD
+++ b/trpc/stream/http/BUILD
@@ -114,6 +114,7 @@ cc_library(
     name = "http_stream",
     deps = [
         ":http_stream_impl",
+        "//trpc/util/http:response",
     ],
 )
 
@@ -136,7 +137,7 @@ cc_library(
     deps = [
         ":http_stream_hdrs",
         "//trpc/util/http:request",
-        "//trpc/util/http:response",
+        "//trpc/util/http:response_hdrs",
     ],
 )
 

--- a/trpc/stream/http/async/BUILD
+++ b/trpc/stream/http/async/BUILD
@@ -36,7 +36,6 @@ cc_library(
         "//trpc/stream/http/async/client:stream",
         "//trpc/stream/http/async/server:stream",
         "//trpc/util/http:request",
-        "//trpc/util/http:response",
         "//trpc/util/http:util",
     ],
 )

--- a/trpc/stream/http/async/client/BUILD
+++ b/trpc/stream/http/async/client/BUILD
@@ -10,7 +10,7 @@ cc_library(
         "//trpc/client:client_context",
         "//trpc/filter:client_filter_controller",
         "//trpc/stream/http/async:stream",
-        "//trpc/util/http:response",
+        "//trpc/util/http:response_hdrs",
     ],
 )
 

--- a/trpc/tools/comm/BUILD
+++ b/trpc/tools/comm/BUILD
@@ -8,7 +8,6 @@ cc_library(
     hdrs = ["utils.h"],
     deps = [
         "@com_google_protobuf//:protobuf",
-        "@com_google_protobuf//:protoc_lib",
     ],
 )
 

--- a/trpc/tools/trpc_cpp_plugin/BUILD
+++ b/trpc/tools/trpc_cpp_plugin/BUILD
@@ -12,7 +12,6 @@ cc_library(
         "//trpc/tools/comm:utils",
         "@com_github_fmtlib_fmt//:fmtlib",
         "@com_google_protobuf//:protobuf",
-        "@com_google_protobuf//:protoc_lib",
     ],
 )
 
@@ -40,7 +39,6 @@ cc_library(
         "//trpc/tools/comm:utils",
         "@com_github_fmtlib_fmt//:fmtlib",
         "@com_google_protobuf//:protobuf",
-        "@com_google_protobuf//:protoc_lib",
     ],
 )
 
@@ -54,7 +52,6 @@ cc_library(
         "//trpc/tools/comm:utils",
         "@com_github_fmtlib_fmt//:fmtlib",
         "@com_google_protobuf//:protobuf",
-        "@com_google_protobuf//:protoc_lib",
     ],
 )
 

--- a/trpc/transport/client/fiber/BUILD
+++ b/trpc/transport/client/fiber/BUILD
@@ -59,6 +59,6 @@ cc_test(
         "//trpc/stream:stream_handler",
         "//trpc/transport/client/fiber/testing:fake_server",
         "//trpc/transport/client/fiber/testing:thread_model_op",
-        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/trpc/transport/client/future/BUILD
+++ b/trpc/transport/client/future/BUILD
@@ -81,6 +81,5 @@ cc_test(
         "//trpc/transport/common:connection_handler_manager",
         "//trpc/util:unique_id",
         "//trpc/util/thread:latch",
-        "@com_google_googletest//:gtest_main",
     ],
 )

--- a/trpc/transport/server/fiber/BUILD
+++ b/trpc/transport/server/fiber/BUILD
@@ -96,6 +96,6 @@ cc_test(
         "//trpc/runtime:fiber_runtime",
         "//trpc/runtime/iomodel/reactor/fiber:fiber_reactor",
         "//trpc/util/thread:latch",
-        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/trpc/util/BUILD
+++ b/trpc/util/BUILD
@@ -45,7 +45,6 @@ cc_test(
     srcs = ["check_test.cc"],
     deps = [
         ":check",
-        "@com_github_gflags_gflags//:gflags",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/trpc/util/buffer/BUILD
+++ b/trpc/util/buffer/BUILD
@@ -36,7 +36,6 @@ cc_test(
     name = "contiguous_buffer_test",
     srcs = ["contiguous_buffer_test.cc"],
     deps = [
-        ":buffer",
         ":contiguous_buffer",
         "@com_google_googletest//:gtest_main",
     ],

--- a/trpc/util/http/BUILD
+++ b/trpc/util/http/BUILD
@@ -202,7 +202,7 @@ cc_library(
     hdrs = ["http_parser.h"],
     visibility = ["//visibility:public"],
     deps = [
-        ":response",
+        ":response_hdrs",
         "@com_github_h2o_picohttpparser//:picohttpparser",
     ],
 )

--- a/trpc/util/internal/BUILD
+++ b/trpc/util/internal/BUILD
@@ -71,7 +71,7 @@ cc_library(
     srcs = ["index_alloc_test.cc"],
     deps = [
         ":index_alloc",
-        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest",
     ],
 )
 


### PR DESCRIPTION
Hi,

I've identified several redundant dependencies in the Bazel build scripts as part of a research project on dependency reduction. Below are some examples:

- **redundant** (can be directly removed)
  - `//trpc/admin:base_funcs -> //trpc/common/config:trpc_config`
  - `//trpc/compressor:trpc_compressor -> //trpc/util/buffer`
  - `//trpc/compressor/common:zlib_util -> //trpc/compressor`
  - ...
- **overly general** (can often be replaced with more specific transitive dependencies)
  - `//trpc/codec/grpc/http2:response -> //trpc/util/http:response` (flatten to `//trpc/util/http:response_hdrs`)
  - `//trpc/common/config:local_file_sink_conf -> :default_log_conf` (flatten to `:default_log_conf_h` and `:default_log_conf_parser`)
  - `//trpc/util/internal:index_alloc_test -> @com_google_googletest//:gtest_main` (flatten to `@com_google_googletest//:gtest`) 
    - **Note: Many test targets depending on gtest_main already define their own main function.**
  - ...
- **can be lifted** (dependency is only used by dependents, and can be moved there)
  - `//trpc/compressor/lz4:lz4_util -> //trpc/util/buffer` (lifted as `:lz4_compressor_test -> //trpc/util/buffer`)
  - `//trpc/runtime/common:periphery_task_scheduler -> //trpc/util/thread:latch` (lifted as `:periphery_task_scheduler_test -> //trpc/util/thread:latch`)
  - ...

Feel free to leave feedback, suggest improvements, or directly edit this PR.

Thanks for your support!