### PR TITLE
Bugfix: fixed the following bugs

### DIFF
--- a/trpc/future/future_test.cc
+++ b/trpc/future/future_test.cc
@@ -641,15 +641,13 @@ TEST(Future, ThenCopyableExecutor) {
 // Test mltiple threads executor.
 TEST(Future, TestExecuteOkInDifferentThread) {
   static int exec_count = 0;
-  int loop_times = 50000;
+  int loop_times = 500;
   for (int i = 0; i < loop_times; i++) {
     Promise<int> pr;
     auto fut = pr.GetFuture();
     std::thread t([pr = std::move(pr)]() mutable {
-      std::this_thread::sleep_for(std::chrono::nanoseconds(1));
       pr.SetValue(1);
     });
-    std::this_thread::sleep_for(std::chrono::nanoseconds(10000));
     fut.Then([](int&& val) {
       exec_count++;
       return MakeReadyFuture<>();

--- a/trpc/stream/http/async/stream.cc
+++ b/trpc/stream/http/async/stream.cc
@@ -56,7 +56,7 @@ Future<> HttpAsyncStream::PushSendMessage(HttpStreamFramePtr&& msg) {
   return AsyncWrite(std::move(out));
 }
 
-Future<http::HttpHeader> HttpAsyncStream::AsyncReadHeader(int timeout) {
+Future<http::HttpHeader> HttpAsyncStream::AsyncReadHeader(uint32_t timeout) {
   pending_header_.val = Promise<http::HttpHeader>();
 
   auto ft = pending_header_.val.value().GetFuture();
@@ -80,7 +80,7 @@ Future<http::HttpHeader> HttpAsyncStream::AsyncReadHeader(int timeout) {
   return ft;
 }
 
-Future<NoncontiguousBuffer> HttpAsyncStream::AsyncReadChunk(int timeout) {
+Future<NoncontiguousBuffer> HttpAsyncStream::AsyncReadChunk(uint32_t timeout) {
   // it can read only in chunked mode
   if (read_mode_ != DataMode::kChunked) {
     Status status{TRPC_STREAM_UNKNOWN_ERR, 0, "Can't read no chunk data"};
@@ -90,15 +90,15 @@ Future<NoncontiguousBuffer> HttpAsyncStream::AsyncReadChunk(int timeout) {
   return AsyncReadInner(ReadOperation::kReadChunk, 0, timeout);
 }
 
-Future<NoncontiguousBuffer> HttpAsyncStream::AsyncReadAtMost(uint64_t len, int timeout) {
+Future<NoncontiguousBuffer> HttpAsyncStream::AsyncReadAtMost(uint64_t len, uint32_t timeout) {
   return AsyncReadInner(ReadOperation::kReadAtMost, len, timeout);
 }
 
-Future<NoncontiguousBuffer> HttpAsyncStream::AsyncReadExactly(uint64_t len, int timeout) {
+Future<NoncontiguousBuffer> HttpAsyncStream::AsyncReadExactly(uint64_t len, uint32_t timeout) {
   return AsyncReadInner(ReadOperation::kReadExactly, len, timeout);
 }
 
-Future<NoncontiguousBuffer> HttpAsyncStream::AsyncReadInner(ReadOperation op, uint64_t len, int timeout) {
+Future<NoncontiguousBuffer> HttpAsyncStream::AsyncReadInner(ReadOperation op, uint64_t len, uint32_t timeout) {
   if (read_mode_ == DataMode::kNoData) {
     // can not read data when content-length equal to 0
     return MakeReadyFuture<NoncontiguousBuffer>(NoncontiguousBuffer{});

--- a/trpc/stream/http/async/stream.h
+++ b/trpc/stream/http/async/stream.h
@@ -36,11 +36,11 @@ class HttpAsyncStream : public HttpCommonStream {
 
   /// @brief Reads the header asynchronously.
   /// @param timeout time to wait for the header to be ready
-  Future<http::HttpHeader> AsyncReadHeader(int timeout = std::numeric_limits<int>::max());
+  Future<http::HttpHeader> AsyncReadHeader(uint32_t timeout = std::numeric_limits<uint32_t>::max());
 
   /// @brief Reads a chunk in chunked mode asynchronously, note that reading in non-chunked mode will fail
   /// @param timeout time to wait for the header to be ready
-  Future<NoncontiguousBuffer> AsyncReadChunk(int timeout = std::numeric_limits<int>::max());
+  Future<NoncontiguousBuffer> AsyncReadChunk(uint32_t timeout = std::numeric_limits<int>::max());
 
   /// @brief Reads at most len data asynchronously.
   /// @param len max size to read
@@ -50,7 +50,7 @@ class HttpAsyncStream : public HttpCommonStream {
   ///       An empty buffer means that the end has been read
   ///       Usage scenario 1: Limits the maximum length of each read When the memory is limited.
   ///       Usage scenario 2: Gets part of data in time and send it downstream on route server.
-  Future<NoncontiguousBuffer> AsyncReadAtMost(uint64_t len, int timeout = std::numeric_limits<int>::max());
+  Future<NoncontiguousBuffer> AsyncReadAtMost(uint64_t len, uint32_t timeout = std::numeric_limits<uint32_t>::max());
 
   /// @brief Reads data with a fixed length. If eof is read, it will return as much data as there is in the network
   /// @param len size to read
@@ -58,7 +58,7 @@ class HttpAsyncStream : public HttpCommonStream {
   /// @note If the read buffer size is less than the required length, it means that eof has been read.
   ///       Usage scenario 1: The requested data is compressed by a fixed size, and needs to be read and decompressed by
   ///       a fixed size.
-  Future<NoncontiguousBuffer> AsyncReadExactly(uint64_t len, int timeout = std::numeric_limits<int>::max());
+  Future<NoncontiguousBuffer> AsyncReadExactly(uint64_t len, uint32_t timeout = std::numeric_limits<uint32_t>::max());
 
  protected:
   template <class T>
@@ -98,7 +98,7 @@ class HttpAsyncStream : public HttpCommonStream {
 
   /// @brief Creates a scheduled waiting task
   template <class T>
-  void CreatePendingTimer(PendingVal<T>* pending, int timeout);
+  void CreatePendingTimer(PendingVal<T>* pending, uint32_t timeout);
 
   /// @brief Checks the pending state
   template <class T>
@@ -110,7 +110,7 @@ class HttpAsyncStream : public HttpCommonStream {
 
   void NotifyPendingDataQueue();
 
-  Future<NoncontiguousBuffer> AsyncReadInner(ReadOperation op, uint64_t len, int timeout);
+  Future<NoncontiguousBuffer> AsyncReadInner(ReadOperation op, uint64_t len, uint32_t timeout);
 
  protected:
   /// @brief Used to store asynchronous data request
@@ -147,7 +147,7 @@ void HttpAsyncStream::PendingDone(PendingVal<T>* pending) {
 }
 
 template <class T>
-void HttpAsyncStream::CreatePendingTimer(PendingVal<T>* pending, int timeout) {
+void HttpAsyncStream::CreatePendingTimer(PendingVal<T>* pending, uint32_t timeout) {
   TRPC_CHECK_EQ(pending->timer_id, iotimer::InvalidID);
   pending->timer_id = iotimer::Create(timeout, 0, [this, pending]() {
     if (!pending->val) {

--- a/trpc/stream/http/async/stream_reader_writer.h
+++ b/trpc/stream/http/async/stream_reader_writer.h
@@ -32,11 +32,11 @@ class HttpAsyncStreamReader : public RefCounted<HttpAsyncStreamReader> {
 
   /// @brief Reads Header
   /// @param timeout time to wait for the header to be ready
-  Future<http::HttpHeader> ReadHeader(int timeout = std::numeric_limits<int>::max());
+  Future<http::HttpHeader> ReadHeader(uint32_t timeout = std::numeric_limits<uint32_t>::max());
 
   /// @brief Reads a chunk in chunked mode, note that reading in non-chunked mode will fail
   /// @param timeout time to wait for the header to be ready
-  Future<NoncontiguousBuffer> ReadChunk(int timeout = std::numeric_limits<int>::max());
+  Future<NoncontiguousBuffer> ReadChunk(uint32_t timeout = std::numeric_limits<uint32_t>::max());
 
   /// @brief Reads at most len data.
   /// @param len max size to read
@@ -46,7 +46,7 @@ class HttpAsyncStreamReader : public RefCounted<HttpAsyncStreamReader> {
   ///       An empty buffer means that the end has been read
   ///       Usage scenario 1: Limits the maximum length of each read When the memory is limited.
   ///       Usage scenario 2: Gets part of data in time and send it downstream on route server.
-  Future<NoncontiguousBuffer> ReadAtMost(uint64_t len, int timeout = std::numeric_limits<int>::max());
+  Future<NoncontiguousBuffer> ReadAtMost(uint64_t len, uint32_t timeout = std::numeric_limits<uint32_t>::max());
 
   /// @brief Reads data with a fixed length. If eof is read, it will return as much data as there is in the network
   /// @param len size to read
@@ -54,7 +54,7 @@ class HttpAsyncStreamReader : public RefCounted<HttpAsyncStreamReader> {
   /// @note If the read buffer size is less than the required length, it means that eof has been read.
   ///       Usage scenario 1: The requested data is compressed by a fixed size, and needs to be read and decompressed by
   ///       a fixed size.
-  Future<NoncontiguousBuffer> ReadExactly(uint64_t len, int timeout = std::numeric_limits<int>::max());
+  Future<NoncontiguousBuffer> ReadExactly(uint64_t len, uint32_t timeout = std::numeric_limits<uint32_t>::max());
 
  private:
   HttpAsyncStreamPtr stream_{nullptr};
@@ -87,7 +87,7 @@ class HttpClientAsyncStreamReader : public HttpAsyncStreamReader {
   }
 
   /// @brief Reads the status line of response.
-  Future<HttpStatusLine> ReadStatusLine(int timeout = std::numeric_limits<int>::max()) {
+  Future<HttpStatusLine> ReadStatusLine(uint32_t timeout = std::numeric_limits<uint32_t>::max()) {
     return stream_->ReadStatusLine(timeout);
   }
 
@@ -160,11 +160,11 @@ class HttpAsyncStreamReaderWriter : public RefCounted<HttpAsyncStreamReaderWrite
 
   /// @brief Reads Header
   /// @param timeout time to wait for the header to be ready
-  Future<http::HttpHeader> ReadHeader(int timeout = std::numeric_limits<int>::max());
+  Future<http::HttpHeader> ReadHeader(uint32_t timeout = std::numeric_limits<uint32_t>::max());
 
   /// @brief Reads a chunk in chunked mode, note that reading in non-chunked mode will fail
   /// @param timeout time to wait for the header to be ready
-  Future<NoncontiguousBuffer> ReadChunk(int timeout = std::numeric_limits<int>::max());
+  Future<NoncontiguousBuffer> ReadChunk(uint32_t timeout = std::numeric_limits<uint32_t>::max());
 
   /// @brief Reads at most len data.
   /// @param len max size to read
@@ -174,7 +174,7 @@ class HttpAsyncStreamReaderWriter : public RefCounted<HttpAsyncStreamReaderWrite
   ///       An empty buffer means that the end has been read
   ///       Usage scenario 1: Limits the maximum length of each read When the memory is limited.
   ///       Usage scenario 2: Gets part of data in time and send it downstream on route server.
-  Future<NoncontiguousBuffer> ReadAtMost(uint64_t len, int timeout = std::numeric_limits<int>::max());
+  Future<NoncontiguousBuffer> ReadAtMost(uint64_t len, uint32_t timeout = std::numeric_limits<uint32_t>::max());
 
   /// @brief Reads data with a fixed length. If eof is read, it will return as much data as there is in the network
   /// @param len size to read
@@ -182,7 +182,7 @@ class HttpAsyncStreamReaderWriter : public RefCounted<HttpAsyncStreamReaderWrite
   /// @note If the read buffer size is less than the required length, it means that eof has been read.
   ///       Usage scenario 1: The requested data is compressed by a fixed size, and needs to be read and decompressed by
   ///       a fixed size.
-  Future<NoncontiguousBuffer> ReadExactly(uint64_t len, int timeout = std::numeric_limits<int>::max());
+  Future<NoncontiguousBuffer> ReadExactly(uint64_t len, uint32_t timeout = std::numeric_limits<uint32_t>::max());
 
   /// @brief Writes header or trailer
   Future<> WriteHeader(http::HttpHeader&& header);
@@ -247,7 +247,7 @@ class HttpClientAsyncStreamReaderWriter : public HttpAsyncStreamReaderWriter {
   Future<> WriteRequestLine(HttpRequestLine&& req_line) { return writer_->WriteRequestLine(std::move(req_line)); }
 
   /// @brief Reads status line of response.
-  Future<HttpStatusLine> ReadStatusLine(int timeout = std::numeric_limits<int>::max()) {
+  Future<HttpStatusLine> ReadStatusLine(uint32_t timeout = std::numeric_limits<uint32_t>::max()) {
     return reader_->ReadStatusLine(timeout);
   }
 
@@ -279,14 +279,14 @@ Future<> WriteFullResponse(HttpServerAsyncStreamWriterPtr rw, http::HttpResponse
 
 /// @brief Reads a complete request from the stream.
 Future<http::HttpRequestPtr> ReadFullRequest(HttpServerAsyncStreamReaderWriterPtr rw,
-                                             int timeout = std::numeric_limits<int>::max());
+                                             uint32_t timeout = std::numeric_limits<uint32_t>::max());
 Future<http::HttpRequestPtr> ReadFullRequest(HttpServerAsyncStreamReaderPtr rw,
-                                             int timeout = std::numeric_limits<int>::max());
+                                             uint32_t timeout = std::numeric_limits<uint32_t>::max());
 
 /// @brief Reads a complete response from the stream.
 Future<trpc::http::HttpResponsePtr> ReadFullResponse(HttpClientAsyncStreamReaderWriterPtr rw,
-                                                     int timeout = std::numeric_limits<int>::max());
+                                                     uint32_t timeout = std::numeric_limits<uint32_t>::max());
 Future<trpc::http::HttpResponsePtr> ReadFullResponse(HttpClientAsyncStreamReaderPtr rw,
-                                                     int timeout = std::numeric_limits<int>::max());
+                                                     uint32_t timeout = std::numeric_limits<uint32_t>::max());
 
 }  // namespace trpc::stream

--- a/trpc/stream/http/http_client_stream_handler.cc
+++ b/trpc/stream/http/http_client_stream_handler.cc
@@ -25,6 +25,7 @@ StreamReaderWriterProviderPtr HttpClientStreamHandler::CreateStream(StreamOption
 
 int HttpClientStreamHandler::SendMessage(const std::any& msg, NoncontiguousBuffer&& send_data) {
   IoMessage io_message;
+  io_message.context_ext = std::any_cast<const ClientContextPtr>(msg)->GetCurrentContextExt();
   io_message.buffer = std::move(send_data);
   io_message.msg = msg;
   return options_.send(std::move(io_message));

--- a/trpc/stream/http/http_client_stream_handler_test.cc
+++ b/trpc/stream/http/http_client_stream_handler_test.cc
@@ -28,14 +28,17 @@ TEST(HttpClientStreamHandlerTest, Run) {
       stream::StreamOptions options;
       options.send = [](IoMessage&& message) { return 0; };
       stream::HttpClientStreamHandler handler(std::move(options));
-
       EXPECT_TRUE(handler.Init());
-      auto stream = handler.CreateStream(stream::StreamOptions{});
+
+      auto ctx = MakeRefCounted<ClientContext>();
+      stream::StreamOptions options2;
+      options2.context.context = ctx;
+      auto stream = handler.CreateStream(std::move(options2));
       EXPECT_TRUE(stream);
       EXPECT_TRUE(handler.GetHttpStream());
 
       NoncontiguousBuffer in = CreateBufferSlow("hello");
-      EXPECT_EQ(0, handler.SendMessage("", std::move(in)));
+      EXPECT_EQ(0, handler.SendMessage(ctx, std::move(in)));
 
       // Pushes the response header to stream.
       http::HttpResponse http_response;

--- a/trpc/util/thread/mq_thread_pool.cc
+++ b/trpc/util/thread/mq_thread_pool.cc
@@ -55,11 +55,14 @@ bool MQThreadPool::AddTask(Function<void()>&& job) {
     return true;
   }
 
+  auto task = new MQThreadPoolTask(std::move(job));
   // Other threads add tasks to the global queue
-  if (global_task_queue_.Push(new MQThreadPoolTask(std::move(job)))) {
+  if (global_task_queue_.Push(task)) {
     // notify consume
     notifier_.Notify(false);
     return true;
+  } else {
+    delete task;
   }
 
   return false;


### PR DESCRIPTION
- fix the issue that program will cause a core dump at Promise::SetValue rarely when make rpc call from handle or io work thread
- fix MQThreadPool memory leak when queue is full
- fix the issue where the timeout parameter of HTTP asynchronous streaming ReadFullResponse interface did not take effect
- fix the issue that stream length is 0 in HttpServiceProxy streaming request
- correct type of timeout from int to uint32_t in http stream to avoid overflow during conversion
- make tvar sampler remain valid before and after SamplerCollectorStop/Start