### PR TITLE
Bugfix: fixed stack overflow issue when parsing deeply nested JSON with RapidJSON

### DIFF
--- a/trpc/admin/admin_service_test.cc
+++ b/trpc/admin/admin_service_test.cc
@@ -74,7 +74,7 @@ TEST_F(TestAdminService, CheckAdminService) {
   r.Handle("/cmds", context, req1, reply1);
   std::cout << reply1.GetContent() << std::endl;
   rapidjson::Document rsp1_json;
-  rsp1_json.Parse(reply1.GetContent());
+  rsp1_json.Parse<rapidjson::kParseIterativeFlag>(reply1.GetContent());
   ASSERT_FALSE(rsp1_json.HasParseError());
   const rapidjson::Value& cmds = rsp1_json["cmds"];
   ASSERT_TRUE(cmds.IsArray());
@@ -96,7 +96,7 @@ TEST_F(TestAdminService, CheckAdminService) {
   r.Handle("/cmds/loglevel", context, req3, reply3);
   std::cout << reply3.GetContent() << std::endl;
   rapidjson::Document rsp3_json;
-  rsp3_json.Parse(reply3.GetContent());
+  rsp3_json.Parse<rapidjson::kParseIterativeFlag>(reply3.GetContent());
   ASSERT_FALSE(rsp3_json.HasParseError());
   ASSERT_STREQ(rsp3_json["level"].GetString(), "INFO");
 
@@ -107,7 +107,7 @@ TEST_F(TestAdminService, CheckAdminService) {
   r.Handle("/cmds/loglevel", context, req4, reply4);
   std::cout << reply4.GetContent() << std::endl;
   rapidjson::Document rsp4_json;
-  rsp4_json.Parse(reply4.GetContent());
+  rsp4_json.Parse<rapidjson::kParseIterativeFlag>(reply4.GetContent());
   ASSERT_FALSE(rsp4_json.HasParseError());
   ASSERT_STREQ(rsp4_json["level"].GetString(), "ERROR");
 
@@ -125,7 +125,7 @@ TEST_F(TestAdminService, CheckAdminService) {
   r.Handle("/cmds/reload-config", context, req6, reply6);
   std::cout << reply6.GetContent() << std::endl;
   rapidjson::Document rsp6_json;
-  rsp6_json.Parse(reply6.GetContent());
+  rsp6_json.Parse<rapidjson::kParseIterativeFlag>(reply6.GetContent());
   ASSERT_FALSE(rsp6_json.HasParseError());
   ASSERT_STREQ(rsp6_json["message"].GetString(), "reload config ok");
 
@@ -136,7 +136,7 @@ TEST_F(TestAdminService, CheckAdminService) {
   r.Handle("/cmds/watch", context, req7, reply7);
   std::cout << reply7.GetContent() << std::endl;
   rapidjson::Document rsp7_json;
-  rsp7_json.Parse(reply7.GetContent());
+  rsp7_json.Parse<rapidjson::kParseIterativeFlag>(reply7.GetContent());
   ASSERT_FALSE(rsp7_json.HasParseError());
   ASSERT_STREQ(rsp7_json["message"].GetString(), "watching unsupported");
 

--- a/trpc/client/http/http_service_proxy.cc
+++ b/trpc/client/http/http_service_proxy.cc
@@ -815,7 +815,7 @@ Future<rapidjson::Document> HttpServiceProxy::AsyncHttpUnaryInvokeJson(const Cli
       auto* rsp = static_cast<HttpResponseProtocol*>(p.get());
       auto rsp_str = FlattenSlow(rsp->GetNonContiguousProtocolBody());
       rapidjson::Document rsp_json;
-      rsp_json.Parse(rsp_str.c_str(), rsp_str.size());
+      rsp_json.Parse<rapidjson::kParseIterativeFlag>(rsp_str.c_str(), rsp_str.size());
       if (!rsp_str.empty() && rsp_json.HasParseError()) {
         std::string error{
             fmt::format("Http JsonParse Failed: {}", rapidjson::GetParseError_En(rsp_json.GetParseError()))};
@@ -853,7 +853,7 @@ Future<rapidjson::Document> HttpServiceProxy::AsyncHttpUnaryInvokeJson(const Cli
       auto* rsp = static_cast<HttpResponseProtocol*>(p.get());
       auto rsp_str = FlattenSlow(rsp->GetNonContiguousProtocolBody());
       rapidjson::Document rsp_json;
-      rsp_json.Parse(rsp_str.c_str(), rsp_str.size());
+      rsp_json.Parse<rapidjson::kParseIterativeFlag>(rsp_str.c_str(), rsp_str.size());
       if (!rsp_str.empty() && rsp_json.HasParseError()) {
         std::string error{
             fmt::format("Http JsonParse Failed: {}", rapidjson::GetParseError_En(rsp_json.GetParseError()))};

--- a/trpc/client/http/http_service_proxy_test.cc
+++ b/trpc/client/http/http_service_proxy_test.cc
@@ -1357,7 +1357,7 @@ TEST_F(HttpServiceProxyTest, SuccessRspPostJson) {
 
   rapidjson::Document data;
   std::string request_json = "{\"age\":\"18\",\"height\":180}";
-  data.Parse(request_json);
+  data.Parse<rapidjson::kParseIterativeFlag>(request_json);
 
   rapidjson::Document doc;
   Status st = proxy->Post(ctx, "http://127.0.0.1:10002/hello", data, &doc);
@@ -1421,7 +1421,7 @@ TEST_F(HttpServiceProxyTest, SuccessRspPostJsonEmpty) {
   ctx->SetAddr("127.0.0.1", 10002);
   rapidjson::Document data;
   std::string request_json = "{\"age\":\"18\",\"height\":180}";
-  data.Parse(request_json);
+  data.Parse<rapidjson::kParseIterativeFlag>(request_json);
 
   rapidjson::Document doc;
   Status st = proxy->Post(ctx, "http://127.0.0.1:10002/hello", data, &doc);
@@ -2051,7 +2051,7 @@ TEST_F(HttpServiceProxyTest, SuccessRspPutJson) {
 
   rapidjson::Document data;
   std::string request_json = "{\"age\":\"18\",\"height\":180}";
-  data.Parse(request_json);
+  data.Parse<rapidjson::kParseIterativeFlag>(request_json);
 
   rapidjson::Document doc;
   Status st = proxy->Put(ctx, "http://127.0.0.1:10002/hello", data, &doc);
@@ -2115,7 +2115,7 @@ TEST_F(HttpServiceProxyTest, SuccessRspPutJsonEmpty) {
   ctx->SetAddr("127.0.0.1", 10002);
   rapidjson::Document data;
   std::string request_json = "{\"age\":\"18\",\"height\":180}";
-  data.Parse(request_json);
+  data.Parse<rapidjson::kParseIterativeFlag>(request_json);
 
   rapidjson::Document doc;
   Status st = proxy->Put(ctx, "http://127.0.0.1:10002/hello", data, &doc);

--- a/trpc/client/http/testing/http_client_call_testing.cc
+++ b/trpc/client/http/testing/http_client_call_testing.cc
@@ -75,7 +75,7 @@ bool UnaryRpcCallWithPb(const HttpServiceProxyPtr& proxy) {
 bool UnaryRpcCallWithPostingJson(const HttpServiceProxyPtr& proxy) {
   auto ctx = MakeClientContext(proxy);
   rapidjson::Document req_json;
-  req_json.Parse(R"({"msg": "hello world!"})");
+  req_json.Parse<rapidjson::kParseIterativeFlag>(R"({"msg": "hello world!"})"); 
   rapidjson::Document rsp_json;
   auto status = proxy->Post(ctx, "http://example.com/trpc.test.helloworld.Greeter/SayHello", req_json, &rsp_json);
   if (!status.OK()) {
@@ -231,7 +231,7 @@ bool PostString(const HttpServiceProxyPtr& proxy) {
 bool PostJson(const HttpServiceProxyPtr& proxy) {
   auto ctx = MakeClientContext(proxy);
   rapidjson::Document req_json;
-  req_json.Parse(R"({"msg": "hello world!"})");
+  req_json.Parse<rapidjson::kParseIterativeFlag>(R"({"msg": "hello world!"})"); 
   rapidjson::Document rsp_json;
   auto status = proxy->Post(ctx, "http://example.com/foo", req_json, &rsp_json);
   if (!status.OK()) {

--- a/trpc/codec/http/http_client_codec_test.cc
+++ b/trpc/codec/http/http_client_codec_test.cc
@@ -170,7 +170,7 @@ TEST_F(HttpClientCodecTest, FillRequestAsJson) {
 
   rapidjson::Document json;
   std::string request_json = "{\"age\":\"18\",\"height\":180}";
-  json.Parse(request_json);
+  json.Parse<rapidjson::kParseIterativeFlag>(request_json);
 
   ASSERT_TRUE(codec_.FillRequest(context, req_protocol, reinterpret_cast<void*>(&json)));
 

--- a/trpc/codec/http/http_server_codec.cc
+++ b/trpc/codec/http/http_server_codec.cc
@@ -85,7 +85,7 @@ bool SerializationTypeToContentType(uint32_t serialization_type, std::string* co
 
 void ParseTrpcTransInfo(std::string& value, HttpRequestProtocol* req) {
   rapidjson::Document document;
-  document.Parse(value.c_str());
+  document.Parse<rapidjson::kParseIterativeFlag>(value.c_str());
   if (document.IsObject()) {
     for (auto& mem : document.GetObject()) {
       std::string key = mem.name.GetString();

--- a/trpc/serialization/json/json_serialization_test.cc
+++ b/trpc/serialization/json/json_serialization_test.cc
@@ -38,7 +38,7 @@ TEST(JsonSerializationTest, JsonSerializationRapidjsonTest) {
   std::string json_str = "{\"age\":\"18\",\"height\":180}";
 
   rapidjson::Document serialize_document;
-  serialize_document.Parse(json_str.c_str());
+  serialize_document.Parse<rapidjson::kParseIterativeFlag>(json_str.c_str());
 
   ASSERT_TRUE(!serialize_document.HasParseError());
 
@@ -65,7 +65,7 @@ TEST(JsonSerializationTest, EmptyStringJsonDerializationRapidjsonTest) {
   std::string json_str = "";
 
   rapidjson::Document serialize_document;
-  serialize_document.Parse(json_str.c_str());
+  serialize_document.Parse<rapidjson::kParseIterativeFlag>(json_str.c_str());
 
   ASSERT_TRUE(serialize_document.HasParseError());
 

--- a/trpc/server/rpc/rpc_service_impl_test.cc
+++ b/trpc/server/rpc/rpc_service_impl_test.cc
@@ -350,7 +350,7 @@ TEST_F(RpcServiceImplTest, RapidJsonMessage) {
   std::string json_str = "{\"age\":\"18\",\"height\":180}";
 
   rapidjson::Document hello_req;
-  hello_req.Parse(json_str.c_str());
+  hello_req.Parse<rapidjson::kParseIterativeFlag>(json_str.c_str());
 
   ASSERT_TRUE(!hello_req.HasParseError());
 


### PR DESCRIPTION
Bugfix: fixed stack overflow issue when parsing deeply nested JSON with RapidJSON.
    
- use 'rapidjson::kParseIterativeFlag' to avoid stack overlow.